### PR TITLE
Some improvements around resizing/overflowing

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -88,6 +88,25 @@ class VerticalResizer extends React.Component {
   }
 }
 
+class TwoColoredRows extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    // Here we highlight the columns so it is easy to see if the outer layout
+    // is not being resized.
+    return <Layout>
+      <Layout layoutHeight={200}>
+        <div style={{height: '100%', background: 'cyan'}}>Row 2</div>
+      </Layout>
+      <Layout layoutHeight='flex'>
+        <div style={{height: '100%', background: 'pink'}}>Row 2</div>
+      </Layout>
+    </Layout>
+  }
+}
+
 class Nested extends React.Component {
   constructor(props) {
     super(props)
@@ -98,9 +117,7 @@ class Nested extends React.Component {
       <Layout layoutWidth={100}>Column1</Layout>
       <LayoutSplitter />
       <Layout layoutWidth='flex'>
-        <Layout layoutHeight={200}>Row 1</Layout>
-        <LayoutSplitter />
-        <Layout layoutHeight='flex'>Row 2</Layout>
+        <TwoColoredRows />
       </Layout>
     </Layout>
   }

--- a/lib/react-flex-layout-events.jsx
+++ b/lib/react-flex-layout-events.jsx
@@ -1,0 +1,3 @@
+import Events from 'events'
+const events = new Events.EventEmitter()
+export default events

--- a/lib/react-flex-layout-splitter.jsx
+++ b/lib/react-flex-layout-splitter.jsx
@@ -17,16 +17,6 @@ export default class LayoutSplitter extends React.Component {
   componentDidMount() {
     this.document.addEventListener('mouseup', this.handleMouseUp)
     this.document.addEventListener('mousemove', this.handleMouseMove)
-    if (this.props.orientation === 'horizontal') {
-      this.state.layoutWidth = this.props.layoutWidth || 11
-      this.setState(this.state)
-      this.props.layoutChanged()
-    }
-    if (this.props.orientation === 'vertical') {
-      this.state.layoutHeight = this.props.layoutHeight || 11
-      this.setState(this.state)
-      this.props.layoutChanged()
-    }
   }
 
   componentWillUnmount() {
@@ -123,8 +113,8 @@ export default class LayoutSplitter extends React.Component {
     //let orientation = this.props.orientation;
     let classes = ['LayoutSplitter', this.props.orientation];
     let style = {
-      width: this.state.layoutWidth || this.props.containerWidth,
-      height: this.state.layoutHeight || this.props.containerHeight
+      width: this.props.orientation === 'horizontal' ? LayoutSplitter.defaultSize : this.props.containerWidth,
+      height: this.props.orientation === 'vertical' ? LayoutSplitter.defaultSize : this.props.containerHeight
     }
 
     return <div className={classes.join(' ')} style={style} onMouseDown={this.handleMouseDown} />
@@ -136,3 +126,5 @@ LayoutSplitter.propTypes = {
   getPreviousLayout: React.PropTypes.func,
   getNextLayout: React.PropTypes.func
 }
+
+LayoutSplitter.defaultSize = 11

--- a/lib/react-flex-layout-splitter.jsx
+++ b/lib/react-flex-layout-splitter.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import layoutEvents from './react-flex-layout-events.jsx'
 import './react-flex-layout-splitter.css'
 
 export default class LayoutSplitter extends React.Component {
@@ -28,6 +29,7 @@ export default class LayoutSplitter extends React.Component {
     if (this.state.active) {
       let currentPosition = this.props.orientation === 'horizontal' ? event.clientX : event.clientY;
       this.state.newPositionHandler(currentPosition)
+      layoutEvents.emit('layout-changed')
     }
   }
 

--- a/lib/react-flex-layout-splitter.jsx
+++ b/lib/react-flex-layout-splitter.jsx
@@ -48,6 +48,14 @@ export default class LayoutSplitter extends React.Component {
     }
   }
 
+  markEventAsHandled(event) {
+    if (event.preventDefault) {
+      event.preventDefault()
+    } else {
+      event.returnValue = false
+    }
+  }
+
   handleMouseDown(event) {
     let downPosition = this.props.orientation === 'horizontal' ? event.clientX : event.clientY;
     let layoutProp = this.props.orientation === 'horizontal' ? 'layoutWidth' : 'layoutHeight'
@@ -56,20 +64,22 @@ export default class LayoutSplitter extends React.Component {
     let getSizeFunctionName = this.props.orientation === 'horizontal' ? 'getWidth' : 'getHeight'
     let layout1 = this.props.getPreviousLayout()
     let layout2 = this.props.getNextLayout()
-    let isLayout1Flex = layout1.props[layoutProp] === 'flex'
-    let isLayout2Flex = layout2.props[layoutProp] === 'flex'
-    if (isLayout1Flex && isLayout2Flex) {
-      throw new Error('You cannot place a LayoutSplitter between two flex Layouts')
-    }
-
-    const availableSize = layout1[getSizeFunctionName]() + layout2[getSizeFunctionName]();
-    const layout1MinSize = layout1.props[minSizeProp]
-    const layout2MinSize = layout2.props[minSizeProp]
-    const layout1MaxSize = availableSize - layout2MinSize
-    const layout2MaxSize = availableSize - layout1MinSize
 
     if (layout1 && layout2) {
-      this.props.hideSelection()
+      const isLayout1Flex = layout1.props[layoutProp] === 'flex'
+      const isLayout2Flex = layout2.props[layoutProp] === 'flex'
+      if (isLayout1Flex && isLayout2Flex) {
+        throw new Error('You cannot place a LayoutSplitter between two flex Layouts')
+      }
+
+      const availableSize = layout1[getSizeFunctionName]() + layout2[getSizeFunctionName]();
+      const layout1MinSize = layout1.props[minSizeProp]
+      const layout2MinSize = layout2.props[minSizeProp]
+      const layout1MaxSize = availableSize - layout2MinSize
+      const layout2MaxSize = availableSize - layout1MinSize
+
+      this.markEventAsHandled(event)
+
       let newPositionHandler
       if (isLayout1Flex) {
         // Layout 2 has fixed size

--- a/lib/react-flex-layout.jsx
+++ b/lib/react-flex-layout.jsx
@@ -81,6 +81,7 @@ export default class Layout extends React.Component {
       let totalAllocatedWidth = 0
       let numberOfFlexHeights = 0
       let totalAllocatedHeight = 0
+      let numberOfSplitters = 0
       let i = 0
       React.Children.map(this.props.children, childDefinition => {
         var childType = childDefinition.type
@@ -88,7 +89,9 @@ export default class Layout extends React.Component {
           throw new Error('Child Layouts must have either layoutWidth or layoutHeight set')
         }
 
-        if (childType === Layout || childType === LayoutSplitter) {
+        if (childType === LayoutSplitter) {
+          numberOfSplitters++
+        } else if (childType === Layout) {
           let child = this.refs['layout' + i]
           if (childDefinition.props.layoutWidth === 'flex') { numberOfFlexWidths++ }
           else if (!child && this.isNumber(childDefinition.props.layoutWidth)) { totalAllocatedWidth += childDefinition.props.layoutWidth }
@@ -106,9 +109,11 @@ export default class Layout extends React.Component {
       }
       if (numberOfFlexWidths > 0) {
         var thisWidth = this.state.layoutWidth || this.props.containerWidth
+        totalAllocatedWidth = totalAllocatedWidth + numberOfSplitters * LayoutSplitter.defaultSize
         newFlexDimentions.width = (thisWidth - totalAllocatedWidth) / numberOfFlexWidths
       } else if (numberOfFlexHeights > 0) {
         var thisHeight = this.state.layoutHeight || this.props.containerHeight
+        totalAllocatedWidth = totalAllocatedWidth + numberOfSplitters * LayoutSplitter.defaultSize
         newFlexDimentions.height = (thisHeight - totalAllocatedHeight) / numberOfFlexHeights
       }
 
@@ -224,8 +229,8 @@ export default class Layout extends React.Component {
 
 Layout.propTypes = {
   hideSelection: React.PropTypes.bool,
-  layoutWidth: React.PropTypes.number,
-  layoutHeight: React.PropTypes.number,
+  layoutWidth: React.PropTypes.object,
+  layoutHeight: React.PropTypes.object,
   minWidth: React.PropTypes.number,
   minHeight: React.PropTypes.number
 }

--- a/lib/react-flex-layout.jsx
+++ b/lib/react-flex-layout.jsx
@@ -45,12 +45,20 @@ export default class Layout extends React.Component {
     }
   }
 
+  getWidth() {
+    return React.findDOMNode(this).offsetWidth;
+  }
+
   setWidth(newWidth) {
     this.state.layoutWidth = newWidth
     this.setState(this.state)
     if (this.props.layoutChanged) {
       this.props.layoutChanged()
     }
+  }
+
+  getHeight() {
+    return React.findDOMNode(this).offsetHeight;
   }
 
   setHeight(newHeight) {
@@ -215,5 +223,13 @@ export default class Layout extends React.Component {
 }
 
 Layout.propTypes = {
-  hideSelection: React.PropTypes.bool
+  hideSelection: React.PropTypes.bool,
+  layoutWidth: React.PropTypes.number,
+  layoutHeight: React.PropTypes.number,
+  minWidth: React.PropTypes.number,
+  minHeight: React.PropTypes.number
+}
+Layout.defaultProps = {
+  minWidth: 50,
+  minHeight: 50
 }

--- a/lib/react-flex-layout.jsx
+++ b/lib/react-flex-layout.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import LayoutSplitter from './react-flex-layout-splitter.jsx'
+import layoutEvents from './react-flex-layout-events.jsx'
 
 export default class Layout extends React.Component {
   constructor(props) {
@@ -25,22 +26,31 @@ export default class Layout extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize)
+    layoutEvents.addListener('layout-changed', this.handleResize)
     this.handleResize()
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize)
+    layoutEvents.removeListener('layout-changed', this.handleResize)
   }
 
   handleResize() {
+    let newWidth = this.state.layoutWidth
+    let newHeight = this.state.layoutHeight
     if (this.props.fill === 'window' && window) {
-      this.state.layoutWidth = window.innerWidth
-      this.state.layoutHeight = window.innerHeight
-      this.setState(this.state)
+      newWidth = window.innerWidth
+      newHeight = window.innerHeight
     } else if (!this.props.layoutWidth && !this.props.layoutHeight) {
-      let domNode = React.findDOMNode(this)
-      this.state.layoutWidth = domNode.parentElement.clientWidth
-      this.state.layoutHeight = domNode.parentElement.clientHeight
+        const domNode = React.findDOMNode(this)
+        newHeight = domNode.parentElement.clientHeight
+        newWidth = domNode.parentElement.clientWidth
+    }
+    // Only setState if the available size has actually changed.
+    if (this.state.layoutWidth !== newWidth ||
+        this.state.layoutHeight !== newHeight) {
+      this.state.layoutWidth = newWidth
+      this.state.layoutHeight = newHeight
       this.setState(this.state)
     }
   }
@@ -113,7 +123,7 @@ export default class Layout extends React.Component {
         newFlexDimentions.width = (thisWidth - totalAllocatedWidth) / numberOfFlexWidths
       } else if (numberOfFlexHeights > 0) {
         var thisHeight = this.state.layoutHeight || this.props.containerHeight
-        totalAllocatedWidth = totalAllocatedWidth + numberOfSplitters * LayoutSplitter.defaultSize
+        totalAllocatedHeight = totalAllocatedHeight + numberOfSplitters * LayoutSplitter.defaultSize
         newFlexDimentions.height = (thisHeight - totalAllocatedHeight) / numberOfFlexHeights
       }
 
@@ -229,8 +239,6 @@ export default class Layout extends React.Component {
 
 Layout.propTypes = {
   hideSelection: React.PropTypes.bool,
-  layoutWidth: React.PropTypes.object,
-  layoutHeight: React.PropTypes.object,
   minWidth: React.PropTypes.number,
   minHeight: React.PropTypes.number
 }

--- a/lib/react-flex-layout_tests.jsx
+++ b/lib/react-flex-layout_tests.jsx
@@ -1,6 +1,7 @@
 import React from 'react/addons'
 import expect from 'expect'
 import Layout from './react-flex-layout.jsx'
+import layoutEvents from './react-flex-layout-events.jsx'
 
 var TestUtils = React.addons.TestUtils
 document.body.style.margin = 0
@@ -187,7 +188,7 @@ describe('react-flex-layout', function() {
       expect(verticalContainerNode.children[1].offsetHeight).toBe(400)
   })
 
-  it('Resizes self when its parent resizes', () => {
+  it('Resizes when layout-changed is triggered', () => {
     var container = document.createElement('div')
     container.style.height = '500px'
     container.style.width = '500px'
@@ -198,8 +199,9 @@ describe('react-flex-layout', function() {
       </Layout>
     var layout = React.render(toRender, container)
     var layoutNode = React.findDOMNode(layout)
-    
+
     container.style.height = '400px'
+    layoutEvents.emit('layout-changed')
 
     expect(layoutNode.children[0].offsetHeight).toBe(100)
     expect(layoutNode.children[1].offsetHeight).toBe(300)

--- a/lib/react-flex-layout_tests.jsx
+++ b/lib/react-flex-layout_tests.jsx
@@ -187,6 +187,24 @@ describe('react-flex-layout', function() {
       expect(verticalContainerNode.children[1].offsetHeight).toBe(400)
   })
 
+  it('Resizes self when its parent resizes', () => {
+    var container = document.createElement('div')
+    container.style.height = '500px'
+    container.style.width = '500px'
+    document.body.appendChild(container)
+    var toRender = <Layout fill='container'>
+        <Layout layoutHeight={100}>Header</Layout>
+        <Layout layoutHeight='flex'>Content</Layout>
+      </Layout>
+    var layout = React.render(toRender, container)
+    var layoutNode = React.findDOMNode(layout)
+    
+    container.style.height = '400px'
+
+    expect(layoutNode.children[0].offsetHeight).toBe(100)
+    expect(layoutNode.children[1].offsetHeight).toBe(300)
+  })
+
   it('throws when invalid layout width is specified', function() {
       var container = document.createElement('div')
       container.style.height = '500px'

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "webpack-dev-server": "^1.8.2"
   },
   "dependencies": {
+    "events": "^1.0.2",
     "react": "^0.13.2"
   }
 }


### PR DESCRIPTION
* Added global event that allows detached, nested containers to resize themselves when triggered. It is automatically triggered by changing a splitter position.
* Fixed issues around the flex layout where the splitters were not considered in the first pass
* Added minWidth/minHeight properties
* Replaced the unmark-selection-hack by marking the event as handled