### PR TITLE
Prevent mutating the style in the render method to prevent React warn…

### DIFF
--- a/lib/react-flex-layout.jsx
+++ b/lib/react-flex-layout.jsx
@@ -209,15 +209,12 @@ export default class Layout extends React.Component {
       if (className) { className += ' ' }
       className += 'hideSelection'
     }
-    let style = this.props.style || {}
-    style.overflow = 'auto'
-    style.width = width
-    style.height = height
-    if (this.props.fill === 'window') {
-      style.position = 'absolute'
-      style.top = 0
-      style.left = 0
-    }
+    const style = Object.assign({},
+       this.props.style,
+       {overflow: 'auto', width: width, height: height},
+       this.props.fill === 'window' ? {position: 'absolute', top: 0, left:0}: {}
+    )
+
     return <div style={style} className={className}>{children}</div>
   }
 


### PR DESCRIPTION
Mutating a styles object in the render method has been deprecated. The React shows the following warning message:

```
warning.js?8a56:45 Warning: `div` was passed a style object that has previously been mutated. Mutating `style` is deprecated. Consider cloning it beforehand. Check the `render` of `t`. Previous style: {float: "left", overflow: "auto", width: 400, height: 798}. Mutated style: {float: "left", overflow: "auto", width: 401, height: 798}.
```
